### PR TITLE
feat(meta.js): 将meta信息本地化

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -83,7 +83,7 @@ module.exports = {
    ** Headers of the page
    */
   head: {
-    title: 'Optimus',
+    title: '',
     meta: [
       {charset: 'utf-8'},
       {name: 'viewport', content: 'width=device-width, initial-scale=1'},
@@ -91,7 +91,7 @@ module.exports = {
       {
         hid: 'description',
         name: 'description',
-        content: '开发平台'
+        content: ''
       }
     ],
     link: [
@@ -112,7 +112,7 @@ module.exports = {
    ** Customize the progress bar color
    */
   loading: {
-    color: '#1890ff'
+    color: '#5D81F9'
   },
   /**
    * Share variables, mixins, functions across all style files (no @import needed)

--- a/src/assets/global.less
+++ b/src/assets/global.less
@@ -20,7 +20,7 @@ a {
   cursor: pointer;
 
   &:hover {
-    color: #40a9ff;
+    color: @primary-color;
   }
 }
 

--- a/src/assets/var.less
+++ b/src/assets/var.less
@@ -1,1 +1,1 @@
-@primary-color: #1890ff;
+@primary-color: #5D81F9;

--- a/src/const/meta.config.js
+++ b/src/const/meta.config.js
@@ -1,0 +1,33 @@
+const meta = {
+  favicon:
+    'https://deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/favicon32x32.png',
+
+  // html head default title
+  htmlTitle: 'Deepexi-services',
+
+  // 登录表单上的图片
+  loginLogo:
+    'https://deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_%E8%93%9D%E8%89%B2%E5%AD%97%E4%BD%93.svg',
+
+  // 侧边栏logo 没有文字
+  logo:
+    'https://deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo.svg',
+
+  // 侧边栏logo 有文字
+  logoWord:
+    'https://deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_font.svg',
+
+  // 应用名称
+  appName: 'Deepexi-services',
+  copyright: '滴普科技 版权所有',
+
+  // 登录页背景
+  loginBgImg:
+    'https://deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/login-bg.jpg',
+
+  // console 首页背景
+  homePageImg:
+    'https://deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/login-bg.jpg'
+}
+
+export default meta

--- a/src/const/meta.js
+++ b/src/const/meta.js
@@ -6,15 +6,15 @@ const meta = {
   htmlTitle: 'Deepexi-services',
 
   // 登录表单上的图片
-  loginLogo:
+  logoLogin:
     'https://deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_%E8%93%9D%E8%89%B2%E5%AD%97%E4%BD%93.svg',
 
   // 侧边栏logo 没有文字
-  logo:
+  logoSidebar:
     'https://deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo.svg',
 
   // 侧边栏logo 有文字
-  logoWord:
+  logoSidebarWithWord:
     'https://deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_font.svg',
 
   // 应用名称

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -12,7 +12,11 @@
       >
         <div class="logo">
           <nuxt-link to="/">
-            <img class="logo-img" :src="$store.state.meta.logo" alt="logo" />
+            <img
+              class="logo-img"
+              :src="$store.state.meta.logoSidebar"
+              alt="logo"
+            />
             <h1 class="logo-text">{{ $store.state.meta.appName }}</h1>
           </nuxt-link>
         </div>

--- a/src/layouts/login.vue
+++ b/src/layouts/login.vue
@@ -6,9 +6,9 @@
     <div class="login-form">
       <h1 class="title">
         <img
-          v-if="$store.state.meta.loginLogo"
+          v-if="$store.state.meta.logoLogin"
           class="logo-login"
-          :src="$store.state.meta.loginLogo"
+          :src="$store.state.meta.logoLogin"
           alt=""
         />
         <span v-else>{{ $store.state.meta.appName }}</span>

--- a/src/middleware/meta.js
+++ b/src/middleware/meta.js
@@ -1,7 +1,7 @@
 /**
  * Created by levy on 2018/7/10.
  */
-import META from '@/const/meta.config.js'
+import META from '@/const/meta.js'
 
 export default function({store, app}) {
   // if (process.server) return

--- a/src/middleware/meta.js
+++ b/src/middleware/meta.js
@@ -1,15 +1,13 @@
 /**
  * Created by levy on 2018/7/10.
  */
-export default async function({store, app}) {
+import META from '@/const/meta.config.js'
+
+export default function({store, app}) {
   // if (process.server) return
 
   if (!store.state.meta.appName) {
-    try {
-      await store.dispatch('fetchMetaInfo', {projectNo: process.env.PROJECT_NO})
-    } catch (e) {
-      console.log('meta error: ', e)
-    }
+    store.commit('update', {meta: META})
 
     let meta = store.state.meta
     let head = app.head

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -80,17 +80,5 @@ export const actions = {
         menuList: menuResources.payload
       })
     }
-  },
-
-  // 配置的元信息
-  async fetchMetaInfo({commit}) {
-    let resp = await this.$axios.$get(
-      'http://39.98.50.163:3000/mock/691/xpaas-enterprise-contact/security/api/v1/configs'
-    )
-    let meta = {}
-    resp.payload.forEach(item => {
-      meta[item.key] = item.value
-    })
-    commit('update', {meta})
   }
 }


### PR DESCRIPTION
**Why**
- 获取 meta 信息的接口性能问题，而且通常是一次性修改信息。所以将这些信息改为写在项目中

**How**

- meta 信息 存放在 src/const/meta.config.js 中
- 保留了 middleware/meta.js 因为 title 和 favicon 兼容 ie 需要获取 context.app
- 保留了 store.state.meta 保持 meta 信息的状态共享

**Xmind**
![image](https://user-images.githubusercontent.com/27187946/58006160-fa955400-7b19-11e9-8fa3-f2d762536847.png)
